### PR TITLE
Update NotificationTargetContract.php: add noticetime and endtime

### DIFF
--- a/src/NotificationTargetContract.php
+++ b/src/NotificationTargetContract.php
@@ -68,7 +68,16 @@ class NotificationTargetContract extends NotificationTarget
             $tmp['##contract.number##'] = $contract['num'];
             $tmp['##contract.comment##'] = $contract['comment'];
             $tmp['##contract.account##'] = $contract['accounting_number'];
-
+            $tmp['##contract.endtime##'] = Infocom::getWarrantyExpir(
+                $contract["begin_date"],
+                $contract["duration"]
+            );
+            $tmp['##contract.noticetime##'] = Infocom::getWarrantyExpir(
+                $contract["begin_date"],
+                $contract["duration"],
+                $contract["notice"]
+            );
+            
             if ($contract['contracttypes_id']) {
                 $tmp['##contract.type##'] = Dropdown::getDropdownName(
                     'glpi_contracttypes',
@@ -180,6 +189,8 @@ class NotificationTargetContract extends NotificationTarget
             'contract.type'         => _n('Type', 'Types', 1),
             'contract.entity'       => Entity::getTypeName(1),
             'contract.states'       => __('Status'),
+            'contract.endtime'      => __('Contract expired since the'),                
+	        'contract.noticetime'   => __('Contract with notice since the'),
             'contract.time'         => sprintf(
                 __('%1$s / %2$s'),
                 __('Contract expired since the'),


### PR DESCRIPTION
Adding notice time and end time for contract notifications. Before, there was just one "time" tag and no possibility to print the end time on notice and vice-versa.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
